### PR TITLE
Refactorator: Apply setdeploystepenvironment in nsqpy

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,9 +13,11 @@ deploy:
     legacy: true
     role: lyftpypi-staging-iad-deploy
     orca: []
+    environment: staging
   - name: production
     legacy: true
     role: lyftpypi-production-iad-deploy
     automatic: true
+    environment: production
 languages: [python]
 image_type: library


### PR DESCRIPTION
Refactorator would like to apply these changes to your code!  Please shepherd this to production as soon as possible, going through the normal deployment process monitoring this PR as you would any other change.

**You do not need to approve or land this PR. It will be merged automatically. You will still need to deploy the merged commit yourself.**

To reproduce these changes locally, run:
```bash
control ensure control.minimal
control run refactorator.run fix -i nsqpy -f setdeploystepenvironment
```
# setdeploystepenvironment
This refactorator adds an `environment` to deploy steps where it can be trivially inferred (e.g. the name already contains a valid environment).
Deploy steps whose names cannot be trivially inferred will be skipped for now in favor of revisiting later.
This enables the Deploys team to rely on explicit info instead of parsing deploy names.


For more information or questions reach out to [#deploys-bots](https://lyft.slack.com/messages/deploys-bots).
