### PR TITLE
Turn off credentials

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -3,7 +3,7 @@ description: nsq-py
 repository: git@github.com:lyft/nsq-py.git
 team_email: 'devnull@lyft.com'
 slack: '#devx-bots'
-credentials: true
+credentials: false
 builder:
   name: s2i
   params:


### PR DESCRIPTION
With credentials: true, manifestlint errors given the lack of an expected development IAM role for the project.