### PR TITLE
Deprecate nsq-py

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,7 @@
 name: nsqpy
 description: nsq-py
 repository: git@github.com:lyft/nsq-py.git
+disabled: true
 team_email: 'devnull@lyft.com'
 slack: '#devx-bots'
 credentials: false


### PR DESCRIPTION
- This forked version is not being used at Lyft https://sourcegraph.lyft.net/search?q=%5Ensq-py+file:requirements3.txt&patternType=regexp
- This repo is also not in compliance with how OSS forks are to be setup